### PR TITLE
fix: configuring AD admin throws error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,11 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
+  "containerEnv": {
+    "ARM_USE_OIDC": "false",
+    "ARM_USE_MSI": "false",
+    "ARM_USE_CLI": "true"
+  },
   "runArgs": [
     "--env-file",
     ".devcontainer/devcontainer.env"

--- a/versions.tf
+++ b/versions.tf
@@ -11,5 +11,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.0.0"
     }
+
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 1.0.0"
+    }
   }
 }


### PR DESCRIPTION
Configure Active Directory administrator using the AzAPI provider instead of the AzureRM provider.

Fixes equinor/terraform-baseline#124